### PR TITLE
Poll 21 29 for fuel level on the gen-1 Prius Prime

### DIFF
--- a/signalsets/v3/default.json
+++ b/signalsets/v3/default.json
@@ -44,13 +44,13 @@
         }}
     }
   ]},
-{ "hdr": "7C0", "rax": "7C8", "cmd": {"21": "29"}, "freq": 5, "filter": { "to": 2022 }, "dbgfilter": { "to": 2022 },
-  "signals": [
-    {"id": "PRIUSPRIME_FLI_VOL", "path": "Fuel", "fmt": { "len": 8, "max": 127.5, "div": 2, "unit": "liters" }, "name": "Fuel level (volume)", "suggestedMetric": "fuelTankLevel"}
-  ]},
 { "hdr": "7C0", "fcm1": true, "cmd": {"22": "1022"}, "freq": 1, "dbgfilter": { "to": 2019, "years": [2021, 2022], "from": 2027 },
   "signals": [
     {"id": "PRIUSPRIME_FLV", "path": "Fuel", "fmt": { "len": 16, "max": 655, "div": 100, "nullmax": 655, "unit": "liters" }, "name": "Fuel remaining", "suggestedMetric": "fuelTankLevel"}
+  ]},
+{ "hdr": "7C0", "rax": "7C8", "cmd": {"21": "29"}, "freq": 5, "filter": { "to": 2022 }, "dbgfilter": { "to": 2022 },
+  "signals": [
+    {"id": "PRIUSPRIME_FLI_VOL", "path": "Fuel", "fmt": { "len": 8, "max": 127.5, "div": 2, "unit": "liters" }, "name": "Fuel level (volume)", "suggestedMetric": "fuelTankLevel"}
   ]},
 { "hdr": "7D2", "fcm1": true, "cmd": {"22": "1F5B"}, "freq": 1, "dbgfilter": { "to": 2016, "years": [2018, 2019], "from": 2027 },
   "signals": [

--- a/signalsets/v3/default.json
+++ b/signalsets/v3/default.json
@@ -44,6 +44,10 @@
         }}
     }
   ]},
+{ "hdr": "7C0", "rax": "7C8", "cmd": {"21": "29"}, "freq": 5, "filter": { "to": 2022 }, "dbgfilter": { "to": 2022 },
+  "signals": [
+    {"id": "PRIUSPRIME_FLI_VOL", "path": "Fuel", "fmt": { "len": 8, "max": 127.5, "div": 2, "unit": "liters" }, "name": "Fuel level (volume)", "suggestedMetric": "fuelTankLevel"}
+  ]},
 { "hdr": "7C0", "fcm1": true, "cmd": {"22": "1022"}, "freq": 1, "dbgfilter": { "to": 2019, "years": [2021, 2022], "from": 2027 },
   "signals": [
     {"id": "PRIUSPRIME_FLV", "path": "Fuel", "fmt": { "len": 16, "max": 655, "div": 100, "nullmax": 655, "unit": "liters" }, "name": "Fuel remaining", "suggestedMetric": "fuelTankLevel"}


### PR DESCRIPTION
A driver's 2020 Prius Prime scanlog shows the signalset's only fuel command, `7C0 22 1022`, answered 60 of 60 times with `7C8 03 7F 22 11` (serviceNotSupported), and PID `2F` absent from every ECU's `0120` mask. Nothing else in the set supplies fuel, so the app never shows a fuel level for that car.

The sibling gen-4 `Toyota-Prius` reads fuel volume from the same body ECU with `7C0 21 29` (`PRIUS_FLI_VOL`, `A/2` litres; 2019 and 2022 fixtures answer with data), and `Toyota-RAV4-Hybrid` used the same command through 2019. The Prime set never tried it.

This adds `21 29` as `PRIUSPRIME_FLI_VOL` (8-bit, `div 2`, litres, `fuelTankLevel`), filtered to the gen-1 years (≤2022) and debug-only for all of them, so it is polled at the debug cadence and captured without claiming evidence we do not have yet. `22 1022` stays as is. Narrow `dbgfilter` once responses land.

No fixture changes: a command with no captures generates none. `obdb-update` currently fails on the PostHog export (key lacks `query:read`), so fixtures were left untouched rather than regenerated.

## Feedback

- Pelican feedback [#394](https://triage.scout.clutch.engineering/feedback/394) (and its duplicate #393): fuel never moving on a 2020 Prius Prime
